### PR TITLE
feat: 支持重载插件

### DIFF
--- a/dashboard_client.py
+++ b/dashboard_client.py
@@ -1,58 +1,123 @@
 # dashboard_client.py
+
 import os
+import time
+from typing import Any
 
 import aiohttp
 
 from astrbot.api import logger
 from astrbot.core.star.context import Context
+from astrbot.core.star.star import StarMetadata
 
 
 class DashboardClient:
+    """
+    面板 HTTP 客户端
+    - 复用 aiohttp.ClientSession
+    - 自动缓存 & 续期
+    """
+
+    # token 有效期阈值（秒）
+    TOKEN_VALID_THRESHOLD = 23 * 3600
+
     def __init__(self, context: Context):
         self.context = context
+        self.stars: list[StarMetadata] = context.get_all_stars()
+        self.star_manager = self.context._star_manager
 
         dbc = context.get_config().get("dashboard", {})
         self.host = dbc.get("host", "127.0.0.1")
         self.port = int(os.environ.get("DASHBOARD_PORT", dbc.get("port", 6185)))
-
         if self.host == "0.0.0.0":
             self.host = "127.0.0.1"
 
+        # 接口地址
         self.login_url = f"http://{self.host}:{self.port}/api/auth/login"
         self.restart_url = f"http://{self.host}:{self.port}/api/stat/restart-core"
 
-    async def restart(self):
-        """
-        一次性：登录 → 重启 → 关闭 session
-        """
-        async with aiohttp.ClientSession() as session:
-            token = await self._login(session)
-            await self._restart_core(session, token)
+        # 缓存用
+        self._session: aiohttp.ClientSession | None = None
+        self._token: str | None = None
+        self._token_ts: float | None = None
 
-    async def _login(self, session: aiohttp.ClientSession) -> str:
-        dbc = self.context.get_config()["dashboard"]
-        payload = {
-            "username": dbc["username"],
-            "password": dbc["password"],
-        }
+    # -------------------- 生命周期 --------------------
+    async def initialize(self):
+        self._session = aiohttp.ClientSession()
 
-        async with session.post(self.login_url, json=payload) as resp:
+    async def terminate(self):
+        if self._session and not self._session.closed:
+            await self._session.close()
+
+    # -------------------- 公共接口 --------------------
+    async def restart(self) -> None:
+        """重启 AstrBot 核心"""
+        await self._request("POST", self.restart_url)
+
+    # -------------------- 内部工具 --------------------
+    async def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        json: dict[str, Any] | None= None,
+        **kwargs,
+    ) -> dict[str, Any]:
+        """统一网络请求：自动带鉴权、自动续期、自动抛异常"""
+        if self._session is None:
+            raise RuntimeError("请使用 async with DashboardClient() 初始化会话")
+
+        token = await self._ensure_token()
+        headers = {"Authorization": f"Bearer {token}"}
+
+        async with self._session.request(
+            method, url, headers=headers, json=json, **kwargs
+        ) as resp:
+            if resp.status == 401:
+                # 401 说明 token 失效，强制刷新再试一次
+                logger.info("Token 失效，尝试重新登录")
+                token = await self._login()
+                headers["Authorization"] = f"Bearer {token}"
+                async with self._session.request(
+                    method, url, headers=headers, json=json, **kwargs
+                ) as resp2:
+                    resp = resp2
+
             if resp.status != 200:
-                raise RuntimeError(f"登录失败: {resp.status}")
+                raise RuntimeError(f"请求失败 [{resp.status}]: {await resp.text()}")
+
+            # 面板接口统一返回 {"code":0, "msg":"...", "data":...}
+            body = await resp.json()
+            print(body)
+            if body.get("status") != "ok":
+                raise RuntimeError(f"业务错误: {body.get('msg')}")
+            return body.get("data")
+
+    async def _ensure_token(self) -> str:
+        """返回可用 token，必要时自动登录"""
+        now = time.time()
+        if (
+            self._token is None
+            or self._token_ts is None
+            or now - self._token_ts > self.TOKEN_VALID_THRESHOLD
+        ):
+            self._token = await self._login()
+            self._token_ts = now
+        return self._token
+
+    async def _login(self) -> str:
+        """执行登录并返回新 token"""
+        dbc = self.context.get_config()["dashboard"]
+        payload = {"username": dbc["username"], "password": dbc["password"]}
+        if self._session is None:
+            raise RuntimeError("请使用 async with DashboardClient() 初始化会话")
+        async with self._session.post(self.login_url, json=payload) as resp:
+            if resp.status != 200:
+                raise RuntimeError(f"登录失败 [{resp.status}]: {await resp.text()}")
 
             data = await resp.json()
             token = data.get("data", {}).get("token")
-
             if not token:
                 raise RuntimeError(f"登录响应异常: {data}")
-
+            logger.info("登录成功，Token 已更新")
             return token
-
-    async def _restart_core(self, session: aiohttp.ClientSession, token: str):
-        headers = {"Authorization": f"Bearer {token}"}
-
-        async with session.post(self.restart_url, headers=headers) as resp:
-            if resp.status != 200:
-                raise RuntimeError(f"重启失败: {resp.status}")
-
-            logger.info("✅ 已发送重启请求")

--- a/dashboard_client.py
+++ b/dashboard_client.py
@@ -65,7 +65,7 @@ class DashboardClient:
     ) -> dict[str, Any]:
         """统一网络请求：自动带鉴权、自动续期、自动抛异常"""
         if self._session is None:
-            raise RuntimeError("请使用 async with DashboardClient() 初始化会话")
+            raise RuntimeError("请先用 DashboardClient.initialize() 初始化会话")
 
         token = await self._ensure_token()
         headers = {"Authorization": f"Bearer {token}"}
@@ -86,9 +86,7 @@ class DashboardClient:
             if resp.status != 200:
                 raise RuntimeError(f"请求失败 [{resp.status}]: {await resp.text()}")
 
-            # 面板接口统一返回 {"code":0, "msg":"...", "data":...}
             body = await resp.json()
-            print(body)
             if body.get("status") != "ok":
                 raise RuntimeError(f"业务错误: {body.get('msg')}")
             return body.get("data")
@@ -110,7 +108,7 @@ class DashboardClient:
         dbc = self.context.get_config()["dashboard"]
         payload = {"username": dbc["username"], "password": dbc["password"]}
         if self._session is None:
-            raise RuntimeError("请使用 async with DashboardClient() 初始化会话")
+            raise RuntimeError("请先用 DashboardClient.initialize() 初始化会话")
         async with self._session.post(self.login_url, json=payload) as resp:
             if resp.status != 200:
                 raise RuntimeError(f"登录失败 [{resp.status}]: {await resp.text()}")

--- a/main.py
+++ b/main.py
@@ -132,6 +132,9 @@ class RestartPlugin(Star):
 
         # 过滤内置插件
         visible = [m for m in sr if not m.reserved]
+        if not visible:
+            yield event.plain_result("暂无插件")
+            return
 
         # 1. 无参数 -> 展示带序号的插件列表（展示名优先）
         if target is None:
@@ -149,7 +152,7 @@ class RestartPlugin(Star):
             if 0 <= idx < len(visible):
                 plugin_key = visible[idx].name
             else:
-                await event.send(event.plain_result("序号超出范围"))
+                yield event.plain_result("序号超出范围")
                 return
 
         elif str(target).lower() == "all":
@@ -162,7 +165,7 @@ class RestartPlugin(Star):
                     plugin_key = meta.name
                     break
             if plugin_key is None:
-                await event.send(event.plain_result("未找到该插件"))
+                yield event.plain_result("未找到该插件")
                 return
 
         # 3. 真正重载

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from astrbot.core.platform.astr_message_event import AstrMessageEvent
 from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_platform_adapter import (
     AiocqhttpAdapter,
 )
+from astrbot.core.star.star_manager import PluginManager
 
 from .dashboard_client import DashboardClient
 from .restart_scheduler import RestartScheduler
@@ -23,23 +24,24 @@ class RestartPlugin(Star):
     def __init__(self, context: Context, config: AstrBotConfig):
         super().__init__(context)
         self.context = context
+        self.star_manager: PluginManager = self.context._star_manager  # type: ignore
         self.config = config
         self.cache: dict[str, Any] = config.get("restart_cache", {})
-        self.scheduler: RestartScheduler | None = None
         self.restart_cron = config.get("restart_cron")
 
     # ================== 生命周期 ==================
 
     async def initialize(self):
         self.dashboard = DashboardClient(self.context)
+        await self.dashboard.initialize()
         self.scheduler = RestartScheduler(self.context, self.config, self.dashboard)
         if self.config["restart_switch"]:
             await self.scheduler.start()
 
     async def terminate(self):
-        if self.scheduler:
-            await self.scheduler.shutdown()
-        logger.info("定时重启插件已终止")
+        await self.dashboard.terminate()
+        await self.scheduler.shutdown()
+        logger.info("重启插件已终止")
 
     # ================== 重启完成通知 ==================
 
@@ -115,11 +117,65 @@ class RestartPlugin(Star):
             yield event.plain_result(
                 f"已开启定时重启: {cron_to_human(self.config['restart_cron'])}"
             )
-            if self.scheduler:
-                await self.scheduler.start()
+            await self.scheduler.start()
         else:
             self.config["restart_switch"] = False
             self.config.save_config()
             yield event.plain_result("已关闭定时重启")
-            if self.scheduler:
-                await self.scheduler.shutdown()
+            await self.scheduler.shutdown()
+
+    @filter.permission_type(filter.PermissionType.ADMIN)
+    @filter.command("重载")
+    async def reload_plugin(self, event: AstrMessageEvent, target: str | int | None = None):
+        """重载 <插件名|序号|空|all>"""
+        from astrbot.core.star.star import star_registry as sr
+
+        # 过滤内置插件
+        visible = [m for m in sr if not m.reserved]
+
+        # 1. 无参数 -> 展示带序号的插件列表（展示名优先）
+        if target is None:
+            lines = ["需指定插件序号："]
+            for idx, meta in enumerate(visible, start=1):
+                show = meta.display_name or meta.name
+                lines.append(f"{idx}. {show}")
+            await event.send(event.plain_result("\n".join(lines)))
+            return
+
+        # 2. 统一把 target 解析成“内部名” plugin_key
+        plugin_key = None
+        if isinstance(target, int) or str(target).isdigit():
+            idx = int(target) - 1
+            if 0 <= idx < len(visible):
+                plugin_key = visible[idx].name
+            else:
+                await event.send(event.plain_result("序号超出范围"))
+                return
+
+        elif str(target).lower() == "all":
+            plugin_key = None
+
+        else:  # 字符串：支持展示名或内部名
+            tgt = str(target)
+            for meta in sr:
+                if tgt in (meta.display_name, meta.name):
+                    plugin_key = meta.name
+                    break
+            if plugin_key is None:
+                await event.send(event.plain_result("未找到该插件"))
+                return
+
+        # 3. 真正重载
+        success, error_message = await self.star_manager.reload(plugin_key)
+
+        # 4. 结果回显：优先用展示名，没有再剥前缀
+        if plugin_key is None:
+            show_name = "所有插件"
+        else:
+            if meta := next((m for m in sr if (m.name or m.module_path) == plugin_key), None):
+                show_name = str(meta.display_name or meta.name).removeprefix("astrbot_plugin_")
+
+        if success:
+            yield event.plain_result(f"{show_name}重载成功")
+        else:
+            yield event.plain_result(f"{show_name}重载失败：{error_message}")

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,6 +2,6 @@ name: astrbot_plugin_restart
 display_name: 重启插件
 desc: 用命令重启、定时自动重启 AstrBot，以解决bot长时间运行可能出现的“抽风”或内存泄漏问题
 help: 略
-version: v1.0.4
+version: v1.0.5
 author: Zhalslar
 repo: https://github.com/Zhalslar/astrbot_plugin_restart


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

引入可复用的仪表盘 HTTP 客户端，支持令牌缓存，并在 restart 插件中添加用于重新加载插件的管理命令。

新功能：
- 添加一个管理命令，可以根据插件名称、索引或一次性重新加载所有插件，并向用户反馈执行成功或失败的结果。

改进：
- 重构 `DashboardClient`，以复用持久化的 `aiohttp` 会话，支持登录令牌缓存、自动刷新和错误处理。
- 将 `DashboardClient` 的生命周期集成到 restart 插件的初始化/终止流程中，并简化调度器的启动/停止处理逻辑。
- 将保留（内置）插件从可重载插件列表中排除，以提供更清晰的用户交互体验。

日常维护：
- 将 restart 插件的元数据版本提升到 v1.0.5。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce reusable dashboard HTTP client with token caching and add admin command to reload plugins from the restart plugin.

New Features:
- Add an admin command to reload plugins by name, index, or all at once with user feedback on success or failure.

Enhancements:
- Refactor DashboardClient to reuse a persistent aiohttp session with cached login tokens and automatic refresh and error handling.
- Integrate DashboardClient lifecycle into the restart plugin initialize/terminate flow and simplify scheduler start/stop handling.
- Exclude reserved (built-in) plugins from the reloadable plugin list for clearer user interaction.

Chores:
- Bump restart plugin metadata version to v1.0.5.

</details>