### PR TITLE
fix: handle missing dashboard config

### DIFF
--- a/dashboard_client.py
+++ b/dashboard_client.py
@@ -24,7 +24,9 @@ class DashboardClient:
         self.stars: list[StarMetadata] = context.get_all_stars()
         self.star_manager = self.context._star_manager
 
-        dbc = context.get_config().get("dashboard", {})
+        # context.get_config() may be None during some startup/restart phases.
+        app_config = context.get_config() or {}
+        dbc = app_config.get("dashboard") or {}
         self.host = dbc.get("host", "127.0.0.1")
         port_value = os.environ.get("DASHBOARD_PORT") or dbc.get("port", 6185)
         self.port = int(port_value)
@@ -79,7 +81,8 @@ class DashboardClient:
 
     def _generate_jwt(self) -> str:
         """为本地 Dashboard 请求生成 JWT。"""
-        dbc = self.context.get_config()["dashboard"]
+        app_config = self.context.get_config() or {}
+        dbc = app_config.get("dashboard") or {}
         username = dbc.get("username")
         jwt_secret = dbc.get("jwt_secret")
         if not username or not jwt_secret:


### PR DESCRIPTION
## Summary
- guard against `context.get_config()` returning `None` in `DashboardClient`
- avoid direct dashboard config indexing during login
- return a clearer error when dashboard username/password is missing

## Background
The restart command may fail with:

```
'NoneType' object has no attribute 'get'
```

This happens because `context.get_config().get("dashboard", {})` assumes `context.get_config()` is always a dict. During some startup/restart phases it can be `None`.

## Test
- `python -m py_compile *.py`

## Summary by Sourcery

在 `DashboardClient` 中更稳健地处理缺失或不完整的仪表板配置，并将仪表板请求的登录方式切换为基于令牌且带缓存的方案。

Bug 修复：
- 当 `context.get_config()` 返回 `None` 时，通过安全读取仪表板配置来防止崩溃。
- 在缺少必需的仪表板登录凭据或登录失败时，返回更清晰的错误信息。

增强：
- 引入基于登录的令牌获取机制，并为仪表板 API 请求提供自动令牌缓存/刷新逻辑，以替代在本地生成 JWT 的方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle missing or incomplete dashboard configuration more robustly in DashboardClient and switch to token-based login with caching for dashboard requests.

Bug Fixes:
- Prevent crashes when context.get_config() returns None by safely reading the dashboard configuration.
- Return clearer errors when required dashboard login credentials are missing or when login fails.

Enhancements:
- Introduce login-based token acquisition and automatic token caching/refresh for dashboard API requests instead of locally generating JWTs.

</details>